### PR TITLE
Fluid Pipes now choose output direction at random

### DIFF
--- a/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntityFluidPipe.java
+++ b/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntityFluidPipe.java
@@ -262,7 +262,8 @@ public class TileEntityFluidPipe extends blusunrize.immersiveengineering.common.
                         remaining -= handler.fill(Utils.copyFluidStackWithAmount(resource, remaining, !(handler instanceof IFluidPipe)), doFill);
                         busy = false;
                         if (remaining == 0) {
-                            if (outputs.indexOf(facing) != 0) Collections.swap(outputs, outputs.indexOf(facing),0); //Add some bias for extra TPS juice
+                            Collections.shuffle(outputs);
+                            //if (outputs.indexOf(facing) != 0) Collections.swap(outputs, outputs.indexOf(facing),0); //Add some bias for extra TPS juice
                             return maximum;
                         }
                     }


### PR DESCRIPTION
In hopes that they fill up outputs more evenly rather than one at a time