### PR TITLE
Revised fuel burn efficiency and IP compat fixes

### DIFF
--- a/src/main/java/mctmods/immersivetechnology/common/ITContent.java
+++ b/src/main/java/mctmods/immersivetechnology/common/ITContent.java
@@ -211,12 +211,12 @@ public class ITContent {
 		if(Multiblock.enable_boiler && Recipes.register_boiler_recipes) {
 			BoilerRecipe.addRecipe(new FluidStack(FluidRegistry.getFluid("steam"), 1000), new FluidStack(FluidRegistry.WATER, 2000), 40);
 			BoilerRecipe.addRecipe(new FluidStack(FluidRegistry.getFluid("steam"), 1500), new FluidStack(FluidRegistry.getFluid("distwater"), 2000), 40);
-			BoilerRecipe.addFuel(new FluidStack(FluidRegistry.getFluid("biodiesel"), 5), 1, 10);
+			BoilerRecipe.addFuel(new FluidStack(FluidRegistry.getFluid("biodiesel"), 10), 1, 10);
 			if(FluidRegistry.getFluid("gasoline") != null) {
-				BoilerRecipe.addFuel(new FluidStack(FluidRegistry.getFluid("gasoline"), 5), 1, 10);
+				BoilerRecipe.addFuel(new FluidStack(FluidRegistry.getFluid("gasoline"), 50), 1, 10);
 			}
 			if(FluidRegistry.getFluid("diesel") != null) {
-				BoilerRecipe.addFuel(new FluidStack(FluidRegistry.getFluid("diesel"), 5), 1, 10);
+				BoilerRecipe.addFuel(new FluidStack(FluidRegistry.getFluid("diesel"), 7), 1, 10);
 			}
 		}
 		if(Multiblock.enable_distiller && Recipes.register_distiller_recipes) {


### PR DESCRIPTION
Revised fuel burn times to be only marginally more efficient than diesel generators and to achieve parity with Immersive Petroleum energy densities.
--------------------Fuel Burn Efficiency----------------------------
Biodiesel consumption now doubled, as before you could run 3.2 boilers per refinery, netting ~19,660 IF/t with simple water boilers and ~27,648 IF/t with distilled water, compared to the measly 8192 IF/t with diesel generators. 
At 10 mB/t instead of 5, you can run 1.6 boilers, netting 9,830 IF/t with simple water or 14,746 IF/t with distilled water. This makes steam turbines an upgrade to the diesel generator, but not a ~2x bare minimum efficiency upgrade.
------------------------IP Compat-----------------------------------
Diesel burns for 175 ticks/bucket in the diesel generator, biodiesel 125 ticks/bucket. This is a 0.714x fuel consumption, so diesel burns for 7 mB/t to biodiesel's 10mB/t.
Gasoline burns at 5mB/t for 256 IF/t in the portable generator. This is a 10x reduction in energy capacity compared to biodiesel, and as such gasoline should burn for 100mB/t in a boiler. Because 100mB/t of gasoline is relatively hard to achieve with IP, this has been buffed to 50mB/t, which is obtainable with some effort.