### PR TITLE
Fixed Gas Turbine still requiring way too much power to start up

### DIFF
--- a/src/main/java/mctmods/immersivetechnology/common/Config.java
+++ b/src/main/java/mctmods/immersivetechnology/common/Config.java
@@ -145,8 +145,8 @@ public class Config {
 				public static float steamTurbine_speed_maxRotation = 72;
 			}
 			public static class GasTurbine {
-				@Comment({"The power consumption of the electric starter for the Gas Turbine [Default=4096]"})
-				public static int gasTurbine_electric_starter_consumption = 4096;
+				@Comment({"The power consumption of the electric starter for the Gas Turbine [Default=3072]"})
+				public static int gasTurbine_electric_starter_consumption = 3072;
 				@Comment({"The power consumption  of the sparkplug for the Gas Turbine [Default=1024]"})
 				public static int gasTurbine_sparkplug_consumption = 1024;
 				@Comment({"The capacity of the electric starter for the Gas Turbine [Default=3072]"})


### PR DESCRIPTION
Forgot to update one of the default values in the config file, ppl need to check it to see if they have the correct values for gasTurbine_electric_starter_consumption and gasTurbine_electric_starter_size... yes, I know, I'm dumb =P