### PR TITLE
Fixed Cooling Towers only pushing fluids out when processing recipes

### DIFF
--- a/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntityCoolingTowerMaster.java
+++ b/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntityCoolingTowerMaster.java
@@ -245,17 +245,16 @@ public class TileEntityCoolingTowerMaster extends TileEntityCoolingTowerSlave im
     }
 
     private void pumpOutputOut() {
-        if(recipe == null) return;
         if(input0 == null) InitializePoIs();
         IFluidHandler output;
-        if(tanks[2].getFluidAmount() >= recipe.fluidOutput0.amount && (output = FluidUtil.getFluidHandler(world, output0Front, output0.facing.getOpposite())) != null) {
+        if(tanks[2].getFluidAmount() > 0 && (output = FluidUtil.getFluidHandler(world, output0Front, output0.facing.getOpposite())) != null) {
             FluidStack out = tanks[2].getFluid();
             int accepted = output.fill(out, false);
             if(accepted == 0) return;
             int drained = output.fill(Utils.copyFluidStackWithAmount(out, Math.min(out.amount, accepted), false), true);
             this.tanks[2].drain(drained, true);
         }
-        if(tanks[3].getFluidAmount() >= recipe.fluidOutput1.amount && (output = FluidUtil.getFluidHandler(world, output1Front, output1.facing.getOpposite())) != null) {
+        if(tanks[3].getFluidAmount() > 0 && (output = FluidUtil.getFluidHandler(world, output1Front, output1.facing.getOpposite())) != null) {
             FluidStack out = tanks[3].getFluid();
             int accepted = output.fill(out, false);
             if(accepted == 0) return;


### PR DESCRIPTION
As it is right now, not only it is counter-intuitive, it can also cause issues if the outputs get full and the tower becomes unable to run recipes as a result, leading to a condition where it can only be fixed by the player by pumping the outputs with external help, such as fluid pumps.