### PR TITLE
Extracted the maximumReflectorStrength into a config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 modarchivename=MCTImmersiveTechnology
 modgroup=mctmods.immersivetechnology
 modversion=1.9
-modsubversion=101
+modsubversion=102

--- a/src/main/java/mctmods/immersivetechnology/common/Config.java
+++ b/src/main/java/mctmods/immersivetechnology/common/Config.java
@@ -145,6 +145,9 @@ public class Config {
 				public static double solarTower_heat_loss_multiplier = 1.0;
 				@Comment({"How fast the the Solar Tower loses progress in ticks when the heat drops below processing heat level [Default=1]"})
 				public static int solarTower_progress_lossInTicks = 1;
+
+				@Comment({"The maximum strength of the reflectors. Decreasing this reduces the amount of reflectors needed to achieve max processing speed. [Default=227.5]"})
+				public static double solarTower_maximum_reflector_strength = 227.5;
 			}
 			public static class SolarMelter {
 				@Comment({"The capacity of the output tank for the Solar Melter [Default=10000]"})

--- a/src/main/java/mctmods/immersivetechnology/common/Config.java
+++ b/src/main/java/mctmods/immersivetechnology/common/Config.java
@@ -154,6 +154,9 @@ public class Config {
 				public static int solarMelter_output_tankSize = 10000;
 				@Comment({"Default amount of energy per tick the solar melter loses when not processing. Maximum energy input per tick by mirrors is ~30720  [Default=80]"})
 				public static int solarMelter_progress_lossEnergy = 80;
+
+				@Comment({"The maximum strength of the reflectors. Decreasing this reduces the amount of reflectors needed to achieve max processing speed. [Default=227.5]"})
+				public static double solarMelter_maximum_reflector_strength = 227.5;
 			}
 			public static class SolarReflector {
 				@Comment({"The minimum distance between the Solar Reflectors and the Solar Tower [Default=12]"})

--- a/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntitySolarMelterMaster.java
+++ b/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntitySolarMelterMaster.java
@@ -5,6 +5,7 @@ import blusunrize.immersiveengineering.common.util.inventory.IEInventoryHandler;
 import mctmods.immersivetechnology.ImmersiveTechnology;
 import mctmods.immersivetechnology.api.ITUtils;
 import mctmods.immersivetechnology.api.crafting.MeltingCrucibleRecipe;
+import mctmods.immersivetechnology.common.Config;
 import mctmods.immersivetechnology.common.Config.ITConfig.Machines.SolarReflector;
 import mctmods.immersivetechnology.common.Config.ITConfig.Machines.SolarMelter;
 import mctmods.immersivetechnology.common.ITContent;
@@ -35,7 +36,7 @@ public class TileEntitySolarMelterMaster extends TileEntitySolarMelterSlave impl
 	private static int solarMaxRange = SolarReflector.solarReflector_maxRange;
 	private static int solarMinRange = SolarReflector.solarReflector_minRange;
 	private static int energyLossPerTick = SolarMelter.solarMelter_progress_lossEnergy;
-	private static double maximumReflectorStrength = 227.5;
+	private static double maximumReflectorStrength = SolarMelter.solarMelter_maximum_reflector_strength;
 
 	BlockPos fluidOutputPos;
 

--- a/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntitySolarTowerMaster.java
+++ b/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntitySolarTowerMaster.java
@@ -40,7 +40,7 @@ public class TileEntitySolarTowerMaster extends TileEntitySolarTowerSlave implem
 	private static double heatLossMultiplier = SolarTower.solarTower_heat_loss_multiplier;
 	private static float speedMult = SolarTower.solarTower_speed_multiplier;
 	private static double workingHeatLevel = SolarTower.solarTower_heat_workingLevel;
-	private static double maximumReflectorStrength = 227.5;
+	private static double maximumReflectorStrength = SolarTower.solarTower_maximum_reflector_strength;
 
 	BlockPos fluidOutputPos;
 


### PR DESCRIPTION
There is a separate config for the solar tower and the solar melter. This allows modpack makers to tweak the amount of reflectors needed to achieve max efficiency.