### PR TITLE
Fix TileEntityFluidPipe render

### DIFF
--- a/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntityFluidPipeAlternative.java
+++ b/src/main/java/mctmods/immersivetechnology/common/blocks/metal/tileentities/TileEntityFluidPipeAlternative.java
@@ -194,6 +194,7 @@ public class TileEntityFluidPipeAlternative extends blusunrize.immersiveengineer
 			connected.markDirty();
 			world.addBlockEvent(getPos().offset(fd), getBlockType(), 0, 0);
 		}
+		updateConnectionByte(EnumFacing.byIndex(side));
 		world.addBlockEvent(getPos(), getBlockType(), 0, 0);
 	}
 


### PR DESCRIPTION
Right-clicking Immersive Technology's alternate fluid pipe doesn't disconnect it from non-pipes.
This is merely a rendering bug, as the fluid pipe would get disconnected properly on block update or world reload.

Merged TileEntityFluidPipe rendering fix as detailed in https://github.com/BluSunrize/ImmersiveEngineering/pull/3397