### PR TITLE
add altenator power config, add torque key in turbine recipies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,7 +329,7 @@ tasks.register('genIntellijRunsDummy')
 
 tasks.register('speedUpPreRun') {
     doLast {
-        for (String s : new String[]{"Client", "Server", "Data"}) {
+        for (String s in ["Client", "Server", "Data"]) {
             def runConfigFile = file(".idea/runConfigurations/run${s}.xml")
             if (runConfigFile.exists()) {
                 ant.replace(

--- a/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/biodiesel.json
+++ b/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/biodiesel.json
@@ -8,5 +8,6 @@
     "amount": 1000,
     "fluid": "immersivetechnology:flue_gas"
   },
-  "time": 10
+  "time": 10,
+  "torque": 1.0
 }

--- a/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/diesel.json
+++ b/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/diesel.json
@@ -8,5 +8,6 @@
     "amount": 1000,
     "fluid": "immersivetechnology:flue_gas"
   },
-  "time": 10
+  "time": 10,
+  "torque": 1.0
 }

--- a/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/gasoline.json
+++ b/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/gasoline.json
@@ -8,5 +8,6 @@
     "amount": 1000,
     "fluid": "immersivetechnology:flue_gas"
   },
-  "time": 10
+  "time": 10,
+  "torque": 1.0
 }

--- a/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/kerosene.json
+++ b/src/generated/resources/data/immersivetechnology/recipes/gas_turbine/kerosene.json
@@ -8,5 +8,6 @@
     "amount": 1000,
     "fluid": "immersivetechnology:flue_gas"
   },
-  "time": 10
+  "time": 10,
+  "torque": 1.0
 }

--- a/src/generated/resources/data/immersivetechnology/recipes/steam_turbine/steam.json
+++ b/src/generated/resources/data/immersivetechnology/recipes/steam_turbine/steam.json
@@ -8,5 +8,6 @@
     "amount": 100,
     "fluid": "immersivetechnology:exhaust_steam"
   },
-  "time": 1
+  "time": 1,
+  "torque": 1.0
 }

--- a/src/generated/resources/data/immersivetechnology/recipes/steam_turbine/steam_forge.json
+++ b/src/generated/resources/data/immersivetechnology/recipes/steam_turbine/steam_forge.json
@@ -8,5 +8,6 @@
     "amount": 100,
     "fluid": "immersivetechnology:exhaust_steam"
   },
-  "time": 1
+  "time": 1,
+  "torque": 1.0
 }

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/logic/AlternatorLogic.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/logic/AlternatorLogic.java
@@ -19,6 +19,7 @@ import mctmods.immersivetechnology.api.capability.IMechanicalEnergyProvider;
 import mctmods.immersivetechnology.common.multiblocks.helper.ITDisplayContext;
 import mctmods.immersivetechnology.common.multiblocks.metal.shapes.AlternatorShape;
 import mctmods.immersivetechnology.common.util.multiblock.PoIJSONSchema;
+import mctmods.immersivetechnology.core.ITServerConfig;
 import mctmods.immersivetechnology.core.lib.ITLib;
 import mctmods.immersivetechnology.core.lib.ITSound;
 import mctmods.immersivetechnology.core.registration.ITSounds;
@@ -141,7 +142,8 @@ public class AlternatorLogic implements IMultiblockLogic<AlternatorLogic.State>,
 
     private void generateAndPushEnergy(State state, IMultiblockContext<State> ctx, Level level) {
         double ratio = (double) state.speed / MAX_SPEED;
-        int generatedThisTick = (int) Math.round(ratio * state.torqueMultiplier * MAX_OUTPUT);
+        double factor = Math.max(0D, ITServerConfig.alternatorPowerFactor);
+        int generatedThisTick = (int) Math.round(ratio * state.torqueMultiplier * MAX_OUTPUT * factor);
         List<IEnergyStorage> connected = getConnectedHandlers(ctx, level);
         if (connected.isEmpty()) { state.energy.receiveEnergy(generatedThisTick, false); return; }
         int pushed = distributeFluxProper(connected, generatedThisTick);

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/logic/GasTurbineLogic.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/logic/GasTurbineLogic.java
@@ -314,6 +314,8 @@ public class GasTurbineLogic implements IMultiblockLogic<GasTurbineLogic.State>,
                         GasTurbineRecipe recipe = state.recipeGetter.apply(ctx.getLevel().getRawLevel(), fluid);
                         if (recipe != null && fluid.getAmount() >= recipe.input.getAmount()) {
                             state.tanks.input.drain(recipe.input.getAmount(), FluidAction.EXECUTE);
+                            // The recipe defines how much torque the turbine provides while burning.
+                            state.currentTorque = recipe.torque;
                             if (recipe.fluidOutput != null) {
                                 int filled = state.tanks.output.fill(recipe.fluidOutput, FluidAction.EXECUTE);
                                 if (filled < recipe.fluidOutput.getAmount()) {}
@@ -364,7 +366,7 @@ public class GasTurbineLogic implements IMultiblockLogic<GasTurbineLogic.State>,
 
     private record MechanicalEnergyProvider(State state) implements IMechanicalEnergyProvider {
         @Override public int getSpeed() { return state.speed; }
-        @Override public float getTorque() { return 1f; }
+        @Override public float getTorque() { return state.currentTorque; }
         @Override public int getMaxSpeed() { return MAX_SPEED; }
         @Override public double getBaseMass() { return BASE_MASS; }
         @Override public double getDriveTorque() { return DRIVE_TORQUE; }
@@ -388,6 +390,8 @@ public class GasTurbineLogic implements IMultiblockLogic<GasTurbineLogic.State>,
         public final CapabilityReference<IEnergyStorage> mvInput;
         private final BiFunction<Level, FluidStack, GasTurbineRecipe> recipeGetter;
         public int speed = 0;
+        /** Current torque multiplier (recipe-controlled). Defaults to 1.0 for compatibility. */
+        public float currentTorque = 1.0f;
         public boolean active = false;
         public boolean starterRunning = false;
         public boolean ignited = false;

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/logic/SteamTurbineLogic.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/logic/SteamTurbineLogic.java
@@ -187,10 +187,13 @@ public class SteamTurbineLogic implements IMultiblockLogic<SteamTurbineLogic.Sta
         boolean canRun = currentlyEnabled && hasConsumer;
         float ratio = 0f;
         if (canRun) {
+            // Reset to default each tick; will be overwritten if a recipe is found.
+            state.currentTorque = 1.0f;
             FluidStack fluid = state.tanks.input.getFluid();
             if (fluid.getAmount() > 0) {
                 SteamTurbineRecipe recipe = state.recipeGetter.apply(level, fluid);
                 if (recipe != null) {
+                    state.currentTorque = recipe.torque;
                     float fluidPerTick = (float) recipe.input.getAmount() / recipe.getTotalProcessTime();
                     state.accumConsume += fluidPerTick;
                     int toDrain = (int) state.accumConsume;
@@ -252,7 +255,7 @@ public class SteamTurbineLogic implements IMultiblockLogic<SteamTurbineLogic.Sta
 
     private record MechanicalEnergyProvider(State state) implements IMechanicalEnergyProvider {
         @Override public int getSpeed() { return state.speed; }
-        @Override public float getTorque() { return 1f; }
+        @Override public float getTorque() { return state.currentTorque; }
         @Override public int getMaxSpeed() { return MAX_SPEED; }
         @Override public double getBaseMass() { return BASE_MASS; }
         @Override public double getDriveTorque() { return DRIVE_TORQUE; }
@@ -271,6 +274,8 @@ public class SteamTurbineLogic implements IMultiblockLogic<SteamTurbineLogic.Sta
         public final CapabilityReference<IFluidHandler> fluidOutput;
         private final BiFunction<Level, FluidStack, SteamTurbineRecipe> recipeGetter;
         public int speed = 0;
+        /** Current torque multiplier (recipe-controlled). Defaults to 1.0 for compatibility. */
+        public float currentTorque = 1.0f;
         public boolean active = false;
         public BooleanSupplier isSoundPlaying = () -> false;
         public float animation_fanRotationStep = 0;

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/GasTurbineRecipe.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/GasTurbineRecipe.java
@@ -22,14 +22,21 @@ public class GasTurbineRecipe extends IESerializableRecipe {
 
     public final FluidTagInput input;
     @Nullable public final FluidStack fluidOutput;
+    /**
+     * Dimensionless torque multiplier applied to mechanical output while this recipe is used.
+     *
+     * <p>Defaults to {@code 1.0f} for backwards compatibility with older datapacks.</p>
+     */
+    public final float torque;
     private final int time;
     Lazy<Integer> totalProcessTime;
 
-    public GasTurbineRecipe(ResourceLocation id, FluidTagInput input, @Nullable FluidStack fluidOutput, int time) {
+    public GasTurbineRecipe(ResourceLocation id, FluidTagInput input, @Nullable FluidStack fluidOutput, int time, float torque) {
         super(LAZY_EMPTY, ITRecipeTypes.GAS_TURBINE, id);
         this.input = input;
         this.fluidOutput = fluidOutput;
         this.time = time;
+        this.torque = torque;
         totalProcessTime = Lazy.of(() -> this.time);
     }
 

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/SteamTurbineRecipe.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/SteamTurbineRecipe.java
@@ -22,14 +22,21 @@ public class SteamTurbineRecipe extends IESerializableRecipe {
 
     public final FluidTagInput input;
     @Nullable public final FluidStack fluidOutput;
+    /**
+     * Dimensionless torque multiplier applied to mechanical output while this recipe is used.
+     *
+     * <p>Defaults to {@code 1.0f} for backwards compatibility with older datapacks.</p>
+     */
+    public final float torque;
     private final int time;
     Lazy<Integer> totalProcessTime;
 
-    public SteamTurbineRecipe(ResourceLocation id, FluidTagInput input, @Nullable FluidStack fluidOutput, int time) {
+    public SteamTurbineRecipe(ResourceLocation id, FluidTagInput input, @Nullable FluidStack fluidOutput, int time, float torque) {
         super(LAZY_EMPTY, ITRecipeTypes.STEAM_TURBINE, id);
         this.input = input;
         this.fluidOutput = fluidOutput;
         this.time = time;
+        this.torque = torque;
         totalProcessTime = Lazy.of(() -> this.time);
     }
 

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/builder/GasTurbineRecipeBuilder.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/builder/GasTurbineRecipeBuilder.java
@@ -36,4 +36,9 @@ public class GasTurbineRecipeBuilder extends IEFinishedRecipe<GasTurbineRecipeBu
     public GasTurbineRecipeBuilder addOutput(Fluid fluid, int amount) { return addOutput(new FluidStack(fluid, amount)); }
 
     public GasTurbineRecipeBuilder setTime(int time) { return this.addWriter((jsonObject) -> jsonObject.addProperty("time", time)); }
+
+    /**
+     * Set the torque multiplier produced while this recipe is used.
+     */
+    public GasTurbineRecipeBuilder setTorque(float torque) { return this.addWriter((jsonObject) -> jsonObject.addProperty("torque", torque)); }
 }

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/builder/SteamTurbineRecipeBuilder.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/builder/SteamTurbineRecipeBuilder.java
@@ -36,4 +36,9 @@ public class SteamTurbineRecipeBuilder extends IEFinishedRecipe<SteamTurbineReci
     public SteamTurbineRecipeBuilder addOutput(Fluid fluid, int amount) { return addOutput(new FluidStack(fluid, amount)); }
 
     public SteamTurbineRecipeBuilder setTime(int time) { return this.addWriter((jsonObject) -> jsonObject.addProperty("time", time)); }
+
+    /**
+     * Set the torque multiplier produced while this recipe is used.
+     */
+    public SteamTurbineRecipeBuilder setTorque(float torque) { return this.addWriter((jsonObject) -> jsonObject.addProperty("torque", torque)); }
 }

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/serializer/GasTurbineRecipeSerializer.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/serializer/GasTurbineRecipeSerializer.java
@@ -24,7 +24,8 @@ public class GasTurbineRecipeSerializer extends IERecipeSerializer<GasTurbineRec
         FluidStack fluidOutput = null;
         if (json.has("output")) fluidOutput = ApiUtils.jsonDeserializeFluidStack(json.getAsJsonObject("output"));
         int time = GsonHelper.getAsInt(json, "time");
-        return new GasTurbineRecipe(recipeId, input, fluidOutput, time);
+        float torque = json.has("torque") ? GsonHelper.getAsFloat(json, "torque") : 1.0f;
+        return new GasTurbineRecipe(recipeId, input, fluidOutput, time, torque);
     }
 
     @Override @Nullable public GasTurbineRecipe fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
@@ -32,7 +33,8 @@ public class GasTurbineRecipeSerializer extends IERecipeSerializer<GasTurbineRec
         boolean hasOutput = buffer.readBoolean();
         FluidStack fluidOutput = hasOutput ? buffer.readFluidStack() : null;
         int time = buffer.readInt();
-        return new GasTurbineRecipe(recipeId, input, fluidOutput, time);
+        float torque = buffer.readFloat();
+        return new GasTurbineRecipe(recipeId, input, fluidOutput, time, torque);
     }
 
     @Override public void toNetwork(@NotNull FriendlyByteBuf buffer, GasTurbineRecipe recipe) {
@@ -41,5 +43,6 @@ public class GasTurbineRecipeSerializer extends IERecipeSerializer<GasTurbineRec
         buffer.writeBoolean(hasOutput);
         if (hasOutput) buffer.writeFluidStack(recipe.fluidOutput);
         buffer.writeInt(recipe.getTotalProcessTime());
+        buffer.writeFloat(recipe.torque);
     }
 }

--- a/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/serializer/SteamTurbineRecipeSerializer.java
+++ b/src/main/java/mctmods/immersivetechnology/common/multiblocks/metal/recipe/serializer/SteamTurbineRecipeSerializer.java
@@ -24,7 +24,8 @@ public class SteamTurbineRecipeSerializer extends IERecipeSerializer<SteamTurbin
         FluidStack fluidOutput = null;
         if (json.has("output")) fluidOutput = ApiUtils.jsonDeserializeFluidStack(json.getAsJsonObject("output"));
         int time = GsonHelper.getAsInt(json, "time");
-        return new SteamTurbineRecipe(recipeId, input, fluidOutput, time);
+        float torque = json.has("torque") ? GsonHelper.getAsFloat(json, "torque") : 1.0f;
+        return new SteamTurbineRecipe(recipeId, input, fluidOutput, time, torque);
     }
 
     @Override @Nullable public SteamTurbineRecipe fromNetwork(@NotNull ResourceLocation recipeId, @NotNull FriendlyByteBuf buffer) {
@@ -32,7 +33,8 @@ public class SteamTurbineRecipeSerializer extends IERecipeSerializer<SteamTurbin
         boolean hasOutput = buffer.readBoolean();
         FluidStack fluidOutput = hasOutput ? buffer.readFluidStack() : null;
         int time = buffer.readInt();
-        return new SteamTurbineRecipe(recipeId, input, fluidOutput, time);
+        float torque = buffer.readFloat();
+        return new SteamTurbineRecipe(recipeId, input, fluidOutput, time, torque);
     }
 
     @Override public void toNetwork(@NotNull FriendlyByteBuf buffer, SteamTurbineRecipe recipe) {
@@ -41,5 +43,6 @@ public class SteamTurbineRecipeSerializer extends IERecipeSerializer<SteamTurbin
         buffer.writeBoolean(hasOutput);
         if (hasOutput) buffer.writeFluidStack(recipe.fluidOutput);
         buffer.writeInt(recipe.getTotalProcessTime());
+        buffer.writeFloat(recipe.torque);
     }
 }

--- a/src/main/java/mctmods/immersivetechnology/core/ITServerConfig.java
+++ b/src/main/java/mctmods/immersivetechnology/core/ITServerConfig.java
@@ -11,18 +11,38 @@ public class ITServerConfig {
     private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
 
     public static final ForgeConfigSpec.EnumValue<DisassemblyMode> DISASSEMBLY_MODE;
+    /**
+     * Multiplies the Alternator FE output. 1.0 = vanilla IT balance.
+     *
+     * Effective FE/t = (RPM/MAX_RPM) * torqueMultiplier * MAX_OUTPUT * alternatorPowerFactor
+     */
+    public static final ForgeConfigSpec.DoubleValue ALTERNATOR_POWER_FACTOR;
 
     public static DisassemblyMode disassemblyMode;
+    public static double alternatorPowerFactor;
 
     static {
         BUILDER.push("multiblocks");
         DISASSEMBLY_MODE = BUILDER.comment("Mode for multiblock disassembly. PROCESS_QUEUE: Use gradual queue with fake player. TEMPLATE_BLOCKS: Revert to template blocks like IE.").defineEnum("disassemblyMode", DisassemblyMode.PROCESS_QUEUE);
+
+        ALTERNATOR_POWER_FACTOR = BUILDER
+                .comment(
+                        "Multiplier for Alternator power output.",
+                        "1.0 = default output, 2.0 = double output, 0.5 = half output."
+                )
+                .defineInRange("alternator_power_factor", 1.0D, 0.0D, 1000.0D);
         BUILDER.pop();
     }
 
     public static final ForgeConfigSpec SPEC = BUILDER.build();
 
-    @SubscribeEvent public static void onConfig(final ModConfigEvent event) { if (event.getConfig().getSpec() == SPEC) { disassemblyMode = DISASSEMBLY_MODE.get(); } }
+    @SubscribeEvent
+    public static void onConfig(final ModConfigEvent event) {
+        if (event.getConfig().getSpec() == SPEC) {
+            disassemblyMode = DISASSEMBLY_MODE.get();
+            alternatorPowerFactor = ALTERNATOR_POWER_FACTOR.get();
+        }
+    }
 
     public enum DisassemblyMode {
         PROCESS_QUEUE,

--- a/version.properties
+++ b/version.properties
@@ -1,12 +1,12 @@
-#Sun Jan 25 10:09:53 CET 2026
-build_number=4197
-stage=beta
-version=2.0.1
-version_cctweaked=1.102.0-SNAPSHOT
+#Tue Jan 20 01:16:06 MST 2026
 version_forge=47.4.12
+version_jei=15.20.0.112
+version_cctweaked=1.102.0-SNAPSHOT
+version_parchment=2023.09.03
+version_mc=1.20.1
+stage=beta
+version_patchouli=81
+build_number=4196
 version_ie=1.20.1-10.1.0-171
 version_if=1.0.2
-version_jei=15.20.0.112
-version_mc=1.20.1
-version_parchment=2023.09.03
-version_patchouli=81
+version=2.0.1

--- a/version.properties
+++ b/version.properties
@@ -1,12 +1,12 @@
-#Tue Jan 20 01:16:06 MST 2026
-version_forge=47.4.12
-version_jei=15.20.0.112
-version_cctweaked=1.102.0-SNAPSHOT
-version_parchment=2023.09.03
-version_mc=1.20.1
+#Sun Jan 25 10:09:53 CET 2026
+build_number=4197
 stage=beta
-version_patchouli=81
-build_number=4196
+version=2.0.1
+version_cctweaked=1.102.0-SNAPSHOT
+version_forge=47.4.12
 version_ie=1.20.1-10.1.0-171
 version_if=1.0.2
-version=2.0.1
+version_jei=15.20.0.112
+version_mc=1.20.1
+version_parchment=2023.09.03
+version_patchouli=81


### PR DESCRIPTION
this adds a global power factor for the altenator and allows setting different torques (and with that different output energies) for every turbine recipe. There is backwards compatibility for other datapacks: If no torque is set, it will default to 1
(also changed "for (String s : new String[]{"Client", "Server", "Data"})" to "for (String s in ["Client", "Server", "Data"])" in build.gradle, since my compiler didnt like it the old way)